### PR TITLE
Add support for proxy port

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -28,7 +28,7 @@ const open = function(config) {
         actions: config.actions,
         commands: config.commands,
         host: config.myHost,
-        port: config.myPort
+        port: config.proxyPort || config.myPort
     };
     serverRequest(config.serverHost, config.serverPort, 'register', payload);
 };


### PR DESCRIPTION
To use the proxy port, simply define it in `CentralIntelligence-telegram/client-config.js`